### PR TITLE
using a lighter base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 ############################################################
 # Dockerfile to build OpenTTD container images
-# Based on Ubuntu
+# Based on debian:jessie
 ############################################################
 
-# Set the base image to Ubuntu
-FROM ubuntu:14.04
+# Set the base image to debian:jessie
+FROM debian:jessie
 
 # File Author / Maintainer
 MAINTAINER Mats Bergmann <bateau@sea-shell.org>


### PR DESCRIPTION
Hi Bateau84,

I changed the base image to debian, as I have experience this is a much lighter base image. Also it seems the permission issues you had when downloading the "opengfx" seems to resolve it self.

Also, if you agree on this change, do you have a good way of creating new tags for 1.5.0-beta1 / beta2?