### PR TITLE
Changing startup checks, running openttd in screen and adding script for saving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV loadgame false
 ENV savename save/autosave/exit.sav
 
-RUN apt-get update -qq && apt-get install wget unzip libfontconfig1 libfreetype6 libicu52 liblzo2-2 libsdl1.2debian -y -qq
+RUN apt-get update -qq && apt-get install wget unzip libfontconfig1 libfreetype6 libicu52 liblzo2-2 libsdl1.2debian screen -y -qq
 
 # Download and install openttd
 WORKDIR /tmp/
-RUN wget -q http://binaries.openttd.org/releases/1.5.0/openttd-1.5.0-linux-ubuntu-trusty-amd64.deb && dpkg -i /tmp/openttd-1.4.4-linux-ubuntu-trusty-amd64.deb
+RUN wget -q http://binaries.openttd.org/releases/1.5.0/openttd-1.5.0-linux-ubuntu-trusty-amd64.deb && dpkg -i /tmp/openttd-1.5.0-linux-ubuntu-trusty-amd64.deb
 
 # Get GFX and unzip the files
 WORKDIR /usr/share/games/openttd/baseset/

--- a/files/save.sh
+++ b/files/save.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+screen -S openttd -X stuff "save ../save/autosave/exit"`echo -ne '\015'`

--- a/files/start.sh
+++ b/files/start.sh
@@ -1,10 +1,12 @@
 #/bin/sh
 
-if [ $loadgame = true ]; then
+# Loads the desired game, or prepare to load it next time server starts up!
+if [ $loadgame = true && -f /usr/share/games/openttd/$savename ]; then
 	echo "We are loading a save game!"
-		echo "Lets load $savename"
-		/usr/games/openttd -D -g $savename -x
+	echo "Lets load $savename"
+	screen -S /usr/games/openttd -D -g $savename -x
 else
-	echo "Dont load game"
-	/usr/games/openttd -D -x
+# If game is not found, it creates a new game
+	echo "Creating a new game. (If you spesified a game to load, we did not find it...)"
+	screen -S openttd /usr/games/openttd -D -x
 fi


### PR DESCRIPTION
Hi Bateau84,

Here is some adjustments I have made. Please look through them carefully and comment on my changes if you are not happy with them.

1) Found a typo, when you download the file, but install another one...??!  : "RUN wget -q http://binaries.openttd.org/releases/1.5.0/openttd-1.5.0-linux-ubuntu-trusty-amd64.deb && dpkg -i /tmp/openttd-1.4.4-linux-ubuntu-trusty-amd64.deb"

2) Say you want to start a new game, but when your docker container reboots it should load the saved game, and not create another new game: 
- I have made changes in the startup.sh script, so that it will create a new game if $savename is not found, but load it if $savename is found. 

Also, do you see any use of having a server NOT loading a game on restart of the container? should we make it default to always save to exit.sav, and to always try to load this file on startup? If you would have a new game, you would anyway have new docker container right?

3) I also started openttd in a "screen" so we now have possiblity to run commands to the game from comandline:
screen -S openttd -X stuff "WriteYourCommandHere"`echo -ne '\015'` 

My plan was to run a save game command when the docker container shutsdown. I have however not found a way to execute this script when the "docker stop openttd" command is run. Maybe you have a good idea of how to implement this. I anyway added the script to the files folder.

Please comment if you disagree on any of the changes I made.

Cheers, from Norway ;)
-Frodus