### PR TITLE
Ver. update, new 'loadgame=' option

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -22,8 +22,8 @@ usermod -G users openttd
 chown openttd:openttd /home/openttd -R
 
 ## Download and install openttd
-wget -q http://binaries.openttd.org/releases/1.5.2/openttd-1.5.2-linux-ubuntu-trusty-amd64.deb
-dpkg -i openttd-1.5.2-linux-ubuntu-trusty-amd64.deb
+wget -q http://binaries.openttd.org/releases/1.6.1/openttd-1.6.1-linux-ubuntu-trusty-amd64.deb
+dpkg -i openttd-1.6.1-linux-ubuntu-trusty-amd64.deb
 mkdir -p /etc/service/openttd/
 
 ## Download GFX and install

--- a/runit/start.sh
+++ b/runit/start.sh
@@ -24,6 +24,19 @@ if [ ${LOADGAME_CHECK} != "x" ]; then
                         exec /sbin/setuser openttd /usr/games/openttd -D -x -d ${DEBUG}
                         exit 0
                 ;;
+                'last-autosave')
+
+			savegame=${savepath}/autosave/`ls -rt ${savepath}/autosave/ | tail -n1`
+
+			if [ -r ${savegame} ]; then
+	                        echo "Loading ${savegame}"
+        	                exec /sbin/setuser openttd /usr/games/openttd -D -g ${savegame} -x -d ${DEBUG}
+                	        exit 0
+			else
+				echo "${savegame} not found..."
+				exit 1
+			fi
+                ;;
                 'exit')
 
 			savegame="${savepath}/autosave/exit.sav"


### PR DESCRIPTION
New loadgame option added:
`loadgame='last-autosave'`
loads last autosave.

It's handy for restoring game state i.e. after server failure.