### PR TITLE
update version, fix home and save folder permission issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
-ARG OPENTTD_VERSION="1.11.2"
-ARG OPENGFX_VERSION="0.6.1"
+ARG OPENTTD_VERSION="12.1"
+ARG OPENGFX_VERSION="7.1"
 
 ADD prepare.sh /tmp/prepare.sh
 ADD cleanup.sh /tmp/cleanup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG OPENTTD_VERSION="12.1"
+ARG OPENTTD_VERSION="12.2"
 ARG OPENGFX_VERSION="7.1"
 
 ADD prepare.sh /tmp/prepare.sh

--- a/openttd.sh
+++ b/openttd.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 
-savepath="/home/openttd/.local/share/openttd/save"
+old_openttd_dir="/home/openttd/.openttd"
+new_openttd_dir="/home/openttd/.local/share/openttd"
+
+#check if new openttd profile dir exists
+if [ -d ${new_openttd_dir} ]; then
+  # if exists, set the new path
+  savepath="/home/openttd/.local/share/openttd/save"
+else
+  # if not, leave the old path
+  savepath="/home/openttd/.openttd/save"
+fi
+
 savegame="${savepath}/${savename}"
 LOADGAME_CHECK="${loadgame}x"
 loadgame=${loadgame:-'false'}

--- a/openttd.sh
+++ b/openttd.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-savepath="/home/openttd/.openttd/save"
+savepath="/home/openttd/.local/share/openttd/save"
 savegame="${savepath}/${savename}"
 LOADGAME_CHECK="${loadgame}x"
 loadgame=${loadgame:-'false'}
@@ -15,10 +15,17 @@ if [ ! "$(id -g ${USER})" -eq "$PGID" ]; then groupmod -o -g "$PGID" ${USER} ; f
 if [ "$(grep ${USER} /etc/passwd | cut -d':' -f6)" != "${PHOME}" ]; then
         if [ ! -d ${PHOME} ]; then
                 mkdir -p ${PHOME}
-                chown ${USER}:${USER} ${PHOME}
+                chown ${USER}:${USER} -R ${PHOME}
         fi
         usermod -m -d ${PHOME} ${USER}
 fi
+
+#create save folder and set permissions
+mkdir -p ${savepath}
+chown ${USER}:${USER} -R ${savepath}
+
+#fix home folder permissions
+chown ${USER}:${USER} -R ${PHOME}
 
 echo "
 -----------------------------------

--- a/prepare.sh
+++ b/prepare.sh
@@ -20,7 +20,7 @@ $minimal_apt_get_install dumb-init wget unzip ca-certificates libfontconfig1 lib
 ## Download and install openttd
 wget -q https://cdn.openttd.org/openttd-releases/${OPENTTD_VERSION}/openttd-${OPENTTD_VERSION}-linux-${ID}-${UBUNTU_CODENAME}-amd64.deb
 dpkg -i openttd-${OPENTTD_VERSION}-linux-${ID}-${UBUNTU_CODENAME}-amd64.deb
-
+rm -rf openttd-${OPENTTD_VERSION}-linux-${ID}-${UBUNTU_CODENAME}-amd64.deb
 
 ## Download GFX and install
 mkdir -p /usr/share/games/openttd/baseset/


### PR DESCRIPTION
I had permission problems with save folder, and in general with save folder path.
Now openttd use .local to store files indtead of .openttd folder.
With this modification this issues was fixed.