### PR TITLE
Easier download URL customization and warning fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:24.04
 
-ARG OPENTTD_VERSION="13.4"
-ARG OPENGFX_VERSION="7.1"
+ARG OPENTTD_VERSION="15.3"
+ARG OPENGFX_VERSION="8.0"
+ARG OPENTTD_DOWNLOAD_LINK="https://cdn.openttd.org/openttd-releases/${OPENTTD_VERSION}/openttd-${OPENTTD_VERSION}-linux-generic-amd64.tar.xz"
 
 ADD prepare.sh /tmp/prepare.sh
 ADD cleanup.sh /tmp/cleanup.sh

--- a/buildconfig
+++ b/buildconfig
@@ -1,4 +1,4 @@
 export LC_ALL=C
 export DEBIAN_FRONTEND=noninteractive
 
-minimal_apt_get_install='apt install -yqq --no-install-recommends -o DPkg::Options::=--force-confold -o DPkg::Options::=--force-confdef'
+minimal_apt_get_install='apt-get install -yqq --no-install-recommends -o DPkg::Options::=--force-confold -o DPkg::Options::=--force-confdef'

--- a/prepare.sh
+++ b/prepare.sh
@@ -12,17 +12,17 @@ fi
 echo "deb http://security.ubuntu.com/ubuntu jammy-security main" >> /etc/apt/sources.list
 
 ## Update pkg repos
-apt update -qq
+apt-get update -qq
 
 ## Install things we need
 $minimal_apt_get_install dumb-init wget xz-utils unzip ca-certificates libfontconfig1 libfreetype6 libfluidsynth3 libicu-dev libpng16-16t64 liblzma-dev liblzo2-2 libsdl1.2debian libsdl2-2.0-0 # > /dev/null 2>&1
 
 ## Download and install openttd
-wget -q https://cdn.openttd.org/openttd-releases/${OPENTTD_VERSION}/openttd-${OPENTTD_VERSION}-linux-generic-amd64.tar.xz
-tar -xf openttd-${OPENTTD_VERSION}-linux-generic-amd64.tar.xz
-mkdir -p /usr/share/games/
-mv openttd-${OPENTTD_VERSION}-linux-generic-amd64 /usr/share/games/openttd
-rm openttd-${OPENTTD_VERSION}-linux-generic-amd64.tar.xz
+wget -q -O openttd.tar.xz "${OPENTTD_DOWNLOAD_LINK}"
+mkdir -p /usr/share/games/openttd
+tar -xf openttd.tar.xz -C /usr/share/games/openttd --strip-components=1
+rm openttd.tar.xz
+test -x /usr/share/games/openttd/openttd || { echo "openttd binary missing after extract" >&2; exit 1; }
 
 ## Download GFX and install
 mkdir -p /usr/share/games/openttd/baseset/


### PR DESCRIPTION
Hi there,

I wanted to start a dedicated server with docker but also using JGR's Patch pack, and customized your repo so it is a little bit easier to do so. Feel free to merge if you think this is beneficial, if not also fine - thought i'd just share it.

Example command which i tested:
```
podman build \
        --build-arg OPENTTD_DOWNLOAD_LINK=https://github.com/JGRennison/OpenTTD-patches/releases/download/jgrpp-0.72.4/openttd-jgrpp-0.72.4-linux-generic-amd64.tar.xz \
        -t openttd:jgrpp-0.72.4 .
```

Changes:
- added OPENTTD_DOWNLOAD_LINK as ARG in the docker file
- fixed "apt has no stable cli interface ..." replaced apt with apt-get
- bumped ottd version in Dockerfile